### PR TITLE
Add codespaces configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,6 @@
             "extensions": [
                 "fuellabs.sway-vscode-plugin",
                 "ms-vscode.vscode-typescript-next",
-                "rust-lang.rust-analyzer"
             ]
         }
     }


### PR DESCRIPTION
This PR adds the configuration for the codespaces dev environment. When the user spins up a codespace from this repo, it will come with all of this pre-installed.

VSCode plugins
- Sway VSCode plugin
- Typescript VSCode plugin
- Rust analyzer

Tools
- the fuel toolchain (latest)
- rust & cargo
- typescript
- node
- npm

Happy to add any other plugins or tools that would be useful.

Here is an example of a codespace created with this configuration: https://sdankel-bug-free-computing-machine-9jwrv6qpj6v2p4vp.github.dev/